### PR TITLE
fix: IMAP APPEND — set \Seen on sent-mail copies

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -511,17 +511,20 @@ pub async fn uid_expunge(
 
 /// Append raw RFC822 message to mailbox
 ///
-/// Used for cross-account copy operations. Does not return the new UID
+/// Used for cross-account copy operations and sent-mail archival.
+/// Pass `flags` to set initial flags on the appended message (e.g.
+/// `Some("\\Seen")` for sent mail). Does not return the new UID
 /// directly (would require `UIDPLUS` capability).
 pub async fn append(
     server: &ServerConfig,
     session: &mut ImapSession,
     mailbox: &str,
+    flags: Option<&str>,
     content: &[u8],
 ) -> AppResult<()> {
     timeout(
         socket_timeout(server),
-        session.append(mailbox, None, None, content),
+        session.append(mailbox, flags, None, content),
     )
     .await
     .map_err(|_| AppError::Timeout("APPEND timed out".to_owned()))
@@ -1071,7 +1074,7 @@ mod tests {
         let message = format!(
             "From: sender@example.com\r\nTo: user@example.com\r\nSubject: {subject}\r\n\r\nWrite-path body\r\n"
         );
-        append(&config, &mut session, "INBOX", message.as_bytes())
+        append(&config, &mut session, "INBOX", None, message.as_bytes())
             .await
             .expect("APPEND should succeed");
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1941,6 +1941,7 @@ impl MailImapServer {
                 &self.config,
                 &mut destination_session,
                 input.destination_mailbox.as_str(),
+                None,
                 raw.as_slice(),
             )
             .await
@@ -2756,6 +2757,7 @@ impl MailImapServer {
             &self.config,
             &mut session,
             &input.mailbox,
+            None,
             input.raw_message.as_bytes(),
         )
         .await?;
@@ -3217,7 +3219,7 @@ impl MailImapServer {
             .find(|name| is_sent_folder_name(name))
             .unwrap_or_else(|| "Sent".to_owned());
 
-        imap::append(&self.config, &mut session, &sent_folder, rfc822).await?;
+        imap::append(&self.config, &mut session, &sent_folder, Some("\\Seen"), rfc822).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Mark sent-mail copies as already read when archiving them to the Sent folder.

## Problem

`src/imap.rs::append` currently calls `session.append(mailbox, None, None, content)`, so the copy landing in the Sent folder arrives with no flags set. Every mail sent through `smtp_send_message` (and `smtp_forward_message`) shows up as an unread message in the account's Sent folder. Mail clients consequently count sent messages in their unread badges, and search/filter UIs treat them as new incoming mail.

## Fix

Add a `flags: Option<&str>` parameter to `imap::append` and pass `Some("\\Seen")` from `save_to_sent_folder`. Other call sites (cross-account copy in `imap_copy_to_mailbox`, raw append in `imap_append_message`) keep passing `None` — preserving current behaviour for flows where the user hasn't expressed intent.

## Rebase note (2026-04-22)

This PR originally carried three commits (UTF-8 charset, UUID Message-ID, Seen flag). The first two are now obsolete: c907a77 ("Fix save_to_sent_folder losing HTML and corrupting non-ASCII subjects (v0.4.1)") replaces the hand-rolled RFC822 builder with the lettre-serialized bytes, which already carry `charset=utf-8` correctly and include a proper RFC 5322 Message-ID. Only the IMAP flags fix remains relevant on v0.4.2.

I rebased the PR onto v0.4.2 and kept only commit 92a0a8c. Full context and the diff of what was dropped are in the first PR comment: https://github.com/tecnologicachile/mail-mcp/pull/9#issuecomment-4300189238

## Tests

`cargo test --release` — 64 passed, 0 failed, 3 ignored.

Fixes #8