### PR TITLE
Support tenant-specific OAuth2 token endpoints via MAIL_*_TENANT_ID

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -287,6 +287,11 @@ fn load_oauth2_accounts() -> AppResult<HashMap<String, OAuth2AccountConfig>> {
         let client_id = required_oauth2_env(&format!("{prefix}CLIENT_ID"), &account_id)?;
         let client_secret = required_oauth2_env(&format!("{prefix}CLIENT_SECRET"), &account_id)?;
         let refresh_token = required_oauth2_env(&format!("{prefix}REFRESH_TOKEN"), &account_id)?;
+        let tenant = env::var(format!("{prefix}TENANT_ID"))
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "common".to_owned());
+        let token_url = provider.token_url(&tenant);
 
         oauth2_accounts.insert(
             account_id,
@@ -295,6 +300,7 @@ fn load_oauth2_accounts() -> AppResult<HashMap<String, OAuth2AccountConfig>> {
                 client_id,
                 client_secret: SecretString::new(client_secret.into()),
                 refresh_token: SecretString::new(refresh_token.into()),
+                token_url,
             },
         );
     }
@@ -336,6 +342,11 @@ fn load_graph_oauth2_accounts() -> AppResult<HashMap<String, OAuth2AccountConfig
         let client_id = required_oauth2_env(&format!("{prefix}CLIENT_ID"), &account_id)?;
         let client_secret = required_oauth2_env(&format!("{prefix}CLIENT_SECRET"), &account_id)?;
         let refresh_token = required_oauth2_env(&format!("{prefix}REFRESH_TOKEN"), &account_id)?;
+        let tenant = env::var(format!("{prefix}TENANT_ID"))
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "common".to_owned());
+        let token_url = provider.token_url(&tenant);
 
         accounts.insert(
             account_id,
@@ -344,6 +355,7 @@ fn load_graph_oauth2_accounts() -> AppResult<HashMap<String, OAuth2AccountConfig
                 client_id,
                 client_secret: SecretString::new(client_secret.into()),
                 refresh_token: SecretString::new(refresh_token.into()),
+                token_url,
             },
         );
     }
@@ -403,6 +415,11 @@ fn load_ews_accounts() -> AppResult<(
             Ok(v) if !v.trim().is_empty() => v,
             _ => continue,
         };
+        let tenant = env::var(format!("{prefix}TENANT_ID"))
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "common".to_owned());
+        let token_url = OAuth2Provider::Microsoft.token_url(&tenant);
 
         ews_oauth2.insert(
             account_id,
@@ -411,6 +428,7 @@ fn load_ews_accounts() -> AppResult<(
                 client_id,
                 client_secret: SecretString::new(client_secret.into()),
                 refresh_token: SecretString::new(refresh_token.into()),
+                token_url,
             },
         );
     }

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -57,11 +57,17 @@ impl OAuth2Provider {
         }
     }
 
-    /// Token endpoint URL for this provider
-    pub fn token_url(&self) -> &'static str {
+    /// Token endpoint URL for this provider.
+    ///
+    /// For Microsoft, `tenant` can be a tenant ID (UUID) for tenant-specific
+    /// endpoints, or `"common"` (the default) for the multi-tenant endpoint.
+    /// Tenant-specific endpoints are required for Thunderbird-style tokens.
+    pub fn token_url(&self, tenant: &str) -> String {
         match self {
-            Self::Google => "https://oauth2.googleapis.com/token",
-            Self::Microsoft => "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+            Self::Google => "https://oauth2.googleapis.com/token".to_owned(),
+            Self::Microsoft => format!(
+                "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
+            ),
         }
     }
 }
@@ -75,6 +81,8 @@ pub struct OAuth2AccountConfig {
     pub client_id: String,
     pub client_secret: SecretString,
     pub refresh_token: SecretString,
+    /// Resolved token endpoint URL (built at load time from provider + tenant).
+    pub token_url: String,
 }
 
 // ─── Cached token ────────────────────────────────────────────────────────────
@@ -187,7 +195,7 @@ impl TokenManager {
 
         let response = self
             .http
-            .post(config.provider.token_url())
+            .post(&config.token_url)
             .form(&params)
             .timeout(Duration::from_secs(30))
             .send()
@@ -338,13 +346,12 @@ mod tests {
     #[test]
     fn provider_token_urls() {
         assert_eq!(
-            OAuth2Provider::Google.token_url(),
+            OAuth2Provider::Google.token_url("common"),
             "https://oauth2.googleapis.com/token"
         );
-        assert!(
-            OAuth2Provider::Microsoft
-                .token_url()
-                .contains("login.microsoftonline.com")
+        assert_eq!(
+            OAuth2Provider::Microsoft.token_url("common"),
+            "https://login.microsoftonline.com/common/oauth2/v2.0/token"
         );
     }
 


### PR DESCRIPTION
## Problem

Microsoft OAuth2 tokens issued against a **tenant-specific endpoint** (e.g. obtained via Thunderbird or any app registered in a specific Azure AD tenant) are rejected when the token refresh uses the `/common/` endpoint. The error is typically a silent 401 or `invalid_grant` from Microsoft.

## Fix

`OAuth2Provider::token_url()` now accepts a `tenant` parameter. All three account loaders (`load_oauth2_accounts`, `load_graph_oauth2_accounts`, `load_ews_accounts`) read the existing `MAIL_*_TENANT_ID` env var and build the token URL at load time:

- If `MAIL_<TYPE>_<ACCOUNT>_TENANT_ID` is set → uses `login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token`
- If absent → falls back to `common` (existing behaviour, fully backwards compatible)

## Testing

71 existing tests pass, 0 failures. Verified working with tenant-specific Microsoft tokens.

## Notes

The `TENANT_ID` env var was already expected by users (it appears naturally when copying credentials from Azure AD app registrations) but was previously silently ignored.