### PR TITLE
iCloud: message fetch fix and mailbox alias support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,18 @@ MAIL_IMAP_DEFAULT_SECURE=true
 # MAIL_IMAP_PERSONAL_PORT=993
 # MAIL_IMAP_PERSONAL_SECURE=true
 
+# Apple iCloud (App-Specific Password from https://appleid.apple.com/account/manage)
+# MAIL_IMAP_ICLOUD_HOST=imap.mail.me.com
+# MAIL_IMAP_ICLOUD_PORT=993
+# MAIL_IMAP_ICLOUD_USER=you@icloud.com
+# MAIL_IMAP_ICLOUD_PASS=replace-with-app-specific-password
+# MAIL_IMAP_ICLOUD_SECURE=true
+# MAIL_SMTP_ICLOUD_HOST=smtp.mail.me.com
+# MAIL_SMTP_ICLOUD_PORT=587
+# MAIL_SMTP_ICLOUD_USER=you@icloud.com
+# MAIL_SMTP_ICLOUD_PASS=replace-with-app-specific-password
+# MAIL_SMTP_ICLOUD_SECURE=starttls
+
 # --- Server-wide settings (defaults shown) ---
 # Enable write operations: copy/move/delete/flags
 MAIL_IMAP_WRITE_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ start a NEW session in the project (not `--continue`).
 | Microsoft 365 (enterprise) | Yes | Admin-dependent | Yes | **Yes** | Yes | Yes |
 | Hotmail / Outlook.com | Yes | Blocked by MS | Yes | **Yes** | Yes | Yes |
 | Gmail | Yes | Yes | — | — | Yes | Yes |
+| Apple iCloud | Yes | Yes | — | — | — | Yes |
 | Zoho | Yes | Yes | — | — | — | Yes |
 | Fastmail | Yes | Yes | — | — | — | Yes |
 | Any IMAP/SMTP server | Yes | Yes | — | — | — | Yes |
@@ -406,7 +407,7 @@ binary stays out of the response. Set the default download directory with
 
 | Tool | What it does |
 |------|-------------|
-| `get_setup_guide` | Provider-specific setup instructions (Microsoft OAuth2, Gmail App Passwords, Zoho, etc.) |
+| `get_setup_guide` | Provider-specific setup instructions (Microsoft OAuth2, Gmail/iCloud App Passwords, Zoho, etc.) |
 
 ## Multi-Account
 
@@ -417,6 +418,15 @@ Configure as many accounts as you need:
 MAIL_IMAP_GMAIL_HOST=imap.gmail.com
 MAIL_IMAP_GMAIL_USER=me@gmail.com
 MAIL_IMAP_GMAIL_PASS=app-password
+
+# Apple iCloud (App-Specific Password from appleid.apple.com)
+MAIL_IMAP_ICLOUD_HOST=imap.mail.me.com
+MAIL_IMAP_ICLOUD_USER=you@icloud.com
+MAIL_IMAP_ICLOUD_PASS=app-specific-password
+MAIL_SMTP_ICLOUD_HOST=smtp.mail.me.com
+MAIL_SMTP_ICLOUD_USER=you@icloud.com
+MAIL_SMTP_ICLOUD_PASS=app-specific-password
+MAIL_SMTP_ICLOUD_SECURE=starttls
 
 # Microsoft 365
 MAIL_IMAP_WORK_HOST=outlook.office365.com
@@ -436,7 +446,7 @@ MAIL_SMTP_DEFAULT_PASS=password
 MAIL_SMTP_DEFAULT_SECURE=starttls
 ```
 
-Use `account_id` in tool calls: `"account_id": "gmail"`, `"account_id": "work"`, `"account_id": "default"`.
+Use `account_id` in tool calls: `"account_id": "gmail"`, `"account_id": "icloud"`, `"account_id": "work"`, `"account_id": "default"`.
 
 ## Security
 

--- a/docs/account-setup.md
+++ b/docs/account-setup.md
@@ -145,6 +145,42 @@ MAIL_SMTP_GMAIL_SECURE=starttls
 
 ---
 
+## Apple iCloud
+
+iCloud Mail requires an **App-Specific Password** for IMAP/SMTP access (regular Apple ID password is blocked for third-party clients).
+
+**Prerequisites:** Two-factor authentication (2FA) must be enabled on the Apple ID.
+
+**Step 1 — Create an App-Specific Password:**
+1. Go to: **https://appleid.apple.com/account/manage**
+2. Sign in, then open **Sign-In and Security** → **App-Specific Passwords**
+3. Generate a password (name it e.g. "mail-mcp")
+4. Copy the password — you will not see it again
+
+**Step 2 — Configure:**
+
+Use the full iCloud email as the username (`you@icloud.com`; also works for `@me.com` / `@mac.com`).
+
+```env
+MAIL_IMAP_ICLOUD_HOST=imap.mail.me.com
+MAIL_IMAP_ICLOUD_PORT=993
+MAIL_IMAP_ICLOUD_USER=you@icloud.com
+MAIL_IMAP_ICLOUD_PASS=your-app-specific-password
+MAIL_IMAP_ICLOUD_SECURE=true
+
+MAIL_SMTP_ICLOUD_HOST=smtp.mail.me.com
+MAIL_SMTP_ICLOUD_PORT=587
+MAIL_SMTP_ICLOUD_USER=you@icloud.com
+MAIL_SMTP_ICLOUD_PASS=your-app-specific-password
+MAIL_SMTP_ICLOUD_SECURE=starttls
+```
+
+**Folder names:** iCloud uses `Sent Messages`, `Deleted Messages`, `Junk`, `Drafts`, and `Archive` (not Gmail-style `Sent` / `Trash`). Short aliases such as `Sent` and `Trash` resolve to the provider folder when listing/selecting mailboxes.
+
+**Sent mail:** Third-party SMTP to iCloud does **not** auto-file a copy in Sent. Leave `MAIL_SMTP_SAVE_SENT` at its default (`true`) so the server APPENDs the sent message to `Sent Messages` after SMTP succeeds.
+
+---
+
 ## Zoho Mail
 
 Zoho supports standard password authentication for IMAP and SMTP.

--- a/scripts/run-mcp.sh
+++ b/scripts/run-mcp.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# run-mcp.sh — launch the local mail-mcp binary for MCP stdio clients
+#
+# Why this exists
+# ---------------
+# The server calls dotenvy::dotenv(), which loads `.env` from the process
+# current working directory. Many MCP hosts spawn tools with a CWD that is
+# not the repo root, so `.env` is never found and accounts fail to load.
+# This wrapper always cds to the repository root before exec.
+#
+# What it does
+# ------------
+# 1. Resolve the repo root from this script's location
+# 2. Require a release binary at target/release/mail-mcp
+# 3. Require a .env file at the repo root (copy from .env.example)
+# 4. exec the binary, forwarding all arguments (stdio stays attached)
+#
+# Usage
+# -----
+#   cargo build --release
+#   cp -n .env.example .env   # then fill credentials
+#   ./scripts/run-mcp.sh
+#
+# Point your MCP client command at this script (absolute path recommended).
+# Prefer injecting MAIL_* env vars in the client config when you do not want
+# a local .env file.
+#
+# Not required for production installs (npx, Docker, GitHub release binaries).
+# Those pass configuration through the environment, not a repo-local .env.
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+BIN="$ROOT/target/release/mail-mcp"
+if [[ ! -x "$BIN" ]]; then
+  echo "mail-mcp: missing release binary at $BIN" >&2
+  echo "Build it with: cargo build --release" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ROOT/.env" ]]; then
+  echo "mail-mcp: missing $ROOT/.env (copy from .env.example and fill credentials)" >&2
+  exit 1
+fi
+
+exec "$BIN" "$@"

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -337,19 +337,212 @@ pub async fn fetch_one(
     }
 }
 
-/// Fetch full RFC822 message source
+/// Fetch full message source (headers + body).
 ///
-/// Returns raw bytes of the entire message.
+/// Prefers `BODY.PEEK[]` so the message is not marked `\Seen`. Apple iCloud
+/// (`imap.mail.me.com`) returns empty for `RFC822` but populates `body()` for
+/// `BODY.PEEK[]`. Falls back to `RFC822` for servers that only expose the
+/// Rfc822 attribute.
 pub async fn fetch_raw_message(
     server: &ServerConfig,
     session: &mut ImapSession,
     uid: u32,
 ) -> AppResult<Vec<u8>> {
+    match fetch_one(server, session, uid, "BODY.PEEK[]").await {
+        Ok(fetch) => {
+            if let Some(body) = fetch.body().filter(|b| !b.is_empty()) {
+                return Ok(body.to_vec());
+            }
+        }
+        Err(AppError::NotFound(msg)) => return Err(AppError::NotFound(msg)),
+        Err(AppError::Timeout(msg)) => return Err(AppError::Timeout(msg)),
+        // Protocol/query incompatibility: try RFC822.
+        Err(_) => {}
+    }
+
     let fetch = fetch_one(server, session, uid, "RFC822").await?;
-    let body = fetch
-        .body()
-        .ok_or_else(|| AppError::Internal("message has no RFC822 body".to_owned()))?;
+    let body = fetch.body().filter(|b| !b.is_empty()).ok_or_else(|| {
+        AppError::Internal("message has no body (BODY.PEEK[] and RFC822 both empty)".to_owned())
+    })?;
     Ok(body.to_vec())
+}
+
+/// Common mailbox roles used for short-name alias resolution across providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MailboxRole {
+    Sent,
+    Trash,
+    Drafts,
+    Junk,
+}
+
+/// Return `true` if `name` looks like a Sent folder on any major provider,
+/// including common non-English names. Case-insensitive.
+pub fn is_sent_folder_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "sent"
+            | "sent items"
+            | "sent mail"
+            | "sent messages"
+            | "enviado"
+            | "enviados"
+            | "enviadas"
+            | "elementos enviados"
+            | "correo enviado"
+            | "itens enviados"
+            | "mensagens enviadas"
+            | "envoyés"
+            | "éléments envoyés"
+            | "gesendet"
+            | "gesendete elemente"
+            | "posta inviata"
+            | "inviati"
+            | "verzonden"
+            | "wyslane"
+            | "wysłane"
+    ) || lower.ends_with("/sent")
+        || lower.ends_with("/sent items")
+        || lower.ends_with("/sent mail")
+        || lower.ends_with("/sent messages")
+        || lower.ends_with("/enviado")
+        || lower.ends_with("/enviados")
+        || lower.ends_with("/elementos enviados")
+        || lower.contains("[gmail]/sent")
+}
+
+/// Return `true` if `name` looks like a Trash/Deleted folder.
+pub fn is_trash_folder_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "trash"
+            | "deleted"
+            | "deleted messages"
+            | "deleted items"
+            | "bin"
+            | "papelera"
+            | "elementos eliminados"
+            | "lixeira"
+            | "itens excluídos"
+            | "corbeille"
+            | "éléments supprimés"
+            | "papierkorb"
+            | "gelöschte elemente"
+            | "cestino"
+    ) || lower.ends_with("/trash")
+        || lower.ends_with("/deleted messages")
+        || lower.ends_with("/deleted items")
+        || lower.ends_with("/bin")
+        || lower.contains("[gmail]/trash")
+}
+
+/// Return `true` if `name` looks like a Drafts folder.
+pub fn is_drafts_folder_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "drafts"
+            | "draft"
+            | "borrador"
+            | "borradores"
+            | "rascunhos"
+            | "brouillons"
+            | "entwürfe"
+            | "bozze"
+    ) || lower.ends_with("/drafts")
+        || lower.ends_with("/draft")
+        || lower.contains("[gmail]/drafts")
+}
+
+/// Return `true` if `name` looks like a Junk/Spam folder.
+pub fn is_junk_folder_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "junk"
+            | "spam"
+            | "junk email"
+            | "junk e-mail"
+            | "bulk mail"
+            | "correo no deseado"
+            | "lixo eletrônico"
+            | "lixo eletronico"
+            | "courrier indésirable"
+            | "junk-e-mail"
+    ) || lower.ends_with("/junk")
+        || lower.ends_with("/spam")
+        || lower.contains("[gmail]/spam")
+        || lower.contains("[gmail]/junk")
+}
+
+/// Map a user-facing short mailbox name to a [`MailboxRole`], if it is a known alias.
+///
+/// Case-insensitive. Real provider folder names that are also aliases (e.g.
+/// iCloud `"Sent Messages"`) return `Some` so LIST + exact match can run.
+pub fn mailbox_role_for_alias(name: &str) -> Option<MailboxRole> {
+    let lower = name.trim().to_ascii_lowercase();
+    match lower.as_str() {
+        "sent" | "sent items" | "sent mail" | "sent messages" => Some(MailboxRole::Sent),
+        "trash" | "deleted" | "deleted messages" | "deleted items" | "bin" => {
+            Some(MailboxRole::Trash)
+        }
+        "drafts" | "draft" => Some(MailboxRole::Drafts),
+        "junk" | "spam" | "junk email" | "junk e-mail" | "bulk mail" => Some(MailboxRole::Junk),
+        _ => None,
+    }
+}
+
+fn role_detector(role: MailboxRole) -> fn(&str) -> bool {
+    match role {
+        MailboxRole::Sent => is_sent_folder_name,
+        MailboxRole::Trash => is_trash_folder_name,
+        MailboxRole::Drafts => is_drafts_folder_name,
+        MailboxRole::Junk => is_junk_folder_name,
+    }
+}
+
+/// Resolve a requested mailbox name against a LIST of available folders.
+///
+/// Order: exact match → case-insensitive exact match → role-alias detector →
+/// return `requested` unchanged.
+pub fn resolve_mailbox_among(requested: &str, available: &[impl AsRef<str>]) -> String {
+    if let Some(hit) = available.iter().find(|n| n.as_ref() == requested) {
+        return hit.as_ref().to_owned();
+    }
+    if let Some(hit) = available
+        .iter()
+        .find(|n| n.as_ref().eq_ignore_ascii_case(requested))
+    {
+        return hit.as_ref().to_owned();
+    }
+    if let Some(role) = mailbox_role_for_alias(requested) {
+        let detector = role_detector(role);
+        if let Some(hit) = available.iter().find(|n| detector(n.as_ref())) {
+            return hit.as_ref().to_owned();
+        }
+    }
+    requested.to_owned()
+}
+
+/// Resolve a user-supplied mailbox name to the provider's real folder name.
+///
+/// Fast path: if `requested` is not a known role alias (`INBOX`, custom folders,
+/// already-canonical non-alias names), returns it unchanged without LIST.
+/// When the name is a role alias (`Sent`, `Trash`, …), lists mailboxes and
+/// resolves via [`resolve_mailbox_among`].
+pub async fn resolve_mailbox_name(
+    server: &ServerConfig,
+    session: &mut ImapSession,
+    requested: &str,
+) -> AppResult<String> {
+    if mailbox_role_for_alias(requested).is_none() {
+        return Ok(requested.to_owned());
+    }
+    let listed = list_all_mailboxes(server, session).await?;
+    let available: Vec<&str> = listed.iter().map(async_imap::types::Name::name).collect();
+    Ok(resolve_mailbox_among(requested, &available))
 }
 
 /// Fetch curated headers and flags
@@ -671,6 +864,7 @@ pub async fn uid_expunge_bulk(
 
 #[cfg(test)]
 mod tests {
+
     use std::collections::BTreeMap;
     use std::sync::Arc;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -686,11 +880,106 @@ mod tests {
     use tokio_rustls::TlsConnector;
 
     use super::{
-        append, fetch_flags, fetch_raw_message, list_all_mailboxes, noop, select_mailbox_readonly,
+        MailboxRole, append, fetch_flags, fetch_raw_message, is_drafts_folder_name,
+        is_junk_folder_name, is_sent_folder_name, is_trash_folder_name, list_all_mailboxes,
+        mailbox_role_for_alias, noop, resolve_mailbox_among, select_mailbox_readonly,
         select_mailbox_readwrite, socket_timeout, uid_copy, uid_expunge, uid_move, uid_search,
         uid_store,
     };
     use crate::config::{AccountConfig, ServerConfig};
+
+
+    #[test]
+    fn resolve_mailbox_among_icloud_aliases() {
+        let icloud = [
+            "INBOX",
+            "Sent Messages",
+            "Deleted Messages",
+            "Junk",
+            "Drafts",
+            "Archive",
+        ];
+        assert_eq!(resolve_mailbox_among("Sent", &icloud), "Sent Messages");
+        assert_eq!(resolve_mailbox_among("Trash", &icloud), "Deleted Messages");
+        assert_eq!(resolve_mailbox_among("Junk", &icloud), "Junk");
+        assert_eq!(resolve_mailbox_among("Drafts", &icloud), "Drafts");
+        assert_eq!(
+            resolve_mailbox_among("Sent Messages", &icloud),
+            "Sent Messages"
+        );
+        assert_eq!(
+            resolve_mailbox_among("Deleted Messages", &icloud),
+            "Deleted Messages"
+        );
+    }
+
+    #[test]
+    fn resolve_mailbox_among_gmail_aliases() {
+        let gmail = [
+            "INBOX",
+            "[Gmail]/Sent Mail",
+            "[Gmail]/Trash",
+            "[Gmail]/Drafts",
+            "[Gmail]/Spam",
+            "Work",
+        ];
+        assert_eq!(resolve_mailbox_among("Sent", &gmail), "[Gmail]/Sent Mail");
+        assert_eq!(resolve_mailbox_among("Trash", &gmail), "[Gmail]/Trash");
+        assert_eq!(resolve_mailbox_among("Drafts", &gmail), "[Gmail]/Drafts");
+        assert_eq!(resolve_mailbox_among("Spam", &gmail), "[Gmail]/Spam");
+        assert_eq!(resolve_mailbox_among("Junk", &gmail), "[Gmail]/Spam");
+    }
+
+    #[test]
+    fn resolve_mailbox_among_exact_and_case_and_passthrough() {
+        let boxes = ["INBOX", "Projects", "Sent Items"];
+        assert_eq!(resolve_mailbox_among("Projects", &boxes), "Projects");
+        assert_eq!(resolve_mailbox_among("inbox", &boxes), "INBOX");
+        assert_eq!(resolve_mailbox_among("Sent", &boxes), "Sent Items");
+        // Unknown custom folder is returned unchanged (caller may still select it).
+        assert_eq!(
+            resolve_mailbox_among("MyCustomFolder", &boxes),
+            "MyCustomFolder"
+        );
+        // Alias with no matching folder on this provider stays as requested.
+        assert_eq!(resolve_mailbox_among("Junk", &boxes), "Junk");
+    }
+
+    #[test]
+    fn mailbox_role_for_alias_covers_short_names() {
+        assert_eq!(mailbox_role_for_alias("Sent"), Some(MailboxRole::Sent));
+        assert_eq!(
+            mailbox_role_for_alias("sent messages"),
+            Some(MailboxRole::Sent)
+        );
+        assert_eq!(mailbox_role_for_alias("Trash"), Some(MailboxRole::Trash));
+        assert_eq!(
+            mailbox_role_for_alias("Deleted Messages"),
+            Some(MailboxRole::Trash)
+        );
+        assert_eq!(mailbox_role_for_alias("Drafts"), Some(MailboxRole::Drafts));
+        assert_eq!(mailbox_role_for_alias("spam"), Some(MailboxRole::Junk));
+        assert_eq!(mailbox_role_for_alias("INBOX"), None);
+        assert_eq!(mailbox_role_for_alias("Archive"), None);
+        assert_eq!(mailbox_role_for_alias("Projects"), None);
+    }
+
+    #[test]
+    fn folder_role_detectors_cover_common_providers() {
+        assert!(is_sent_folder_name("[Gmail]/Sent Mail"));
+        assert!(is_sent_folder_name("Sent Messages"));
+        assert!(is_sent_folder_name("Sent Items"));
+        assert!(is_trash_folder_name("Deleted Messages"));
+        assert!(is_trash_folder_name("[Gmail]/Trash"));
+        assert!(is_trash_folder_name("Trash"));
+        assert!(is_drafts_folder_name("Drafts"));
+        assert!(is_drafts_folder_name("[Gmail]/Drafts"));
+        assert!(is_junk_folder_name("Junk"));
+        assert!(is_junk_folder_name("[Gmail]/Spam"));
+        assert!(is_junk_folder_name("Spam"));
+        assert!(!is_trash_folder_name("INBOX"));
+        assert!(!is_junk_folder_name("Archive"));
+    }
 
     /// Holds connection details for a GreenMail test server instance.
     #[derive(Debug, Clone)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -869,6 +869,13 @@ impl MailImapServer {
                     "smtp": "App Password, same as IMAP",
                     "sending": "smtp_send_message"
                 },
+                "icloud": {
+                    "description": "Apple iCloud Mail (@icloud.com, @me.com, @mac.com)",
+                    "imap": "App-Specific Password (https://appleid.apple.com/account/manage → App-Specific Passwords, requires 2FA). Host: imap.mail.me.com:993",
+                    "smtp": "App-Specific Password. Host: smtp.mail.me.com:587 SECURE=starttls",
+                    "sending": "smtp_send_message (third-party SMTP does not auto-file Sent; leave MAIL_SMTP_SAVE_SENT default on)",
+                    "folders": "Sent Messages, Deleted Messages, Junk, Drafts, Archive — short aliases Sent/Trash/Junk/Drafts also resolve"
+                },
                 "zoho": {
                     "description": "Zoho Mail",
                     "imap": "Standard password",
@@ -910,6 +917,7 @@ impl MailImapServer {
                 "microsoft": "https://account.live.com/proofs/AppPassword (requires 2FA)",
                 "microsoft_365": "https://mysignins.microsoft.com/security-info",
                 "gmail": "https://myaccount.google.com/apppasswords (requires 2FA)",
+                "icloud": "https://appleid.apple.com/account/manage (Sign-In and Security → App-Specific Passwords, requires 2FA)",
                 "zoho": "https://accounts.zoho.com/home#security/security_mysessions"
             },
             "full_docs": "See docs/account-setup.md for complete step-by-step guide"
@@ -1203,7 +1211,7 @@ impl MailImapServer {
 
     async fn search_messages_impl(
         &self,
-        input: SearchMessagesInput,
+        mut input: SearchMessagesInput,
     ) -> AppResult<SearchResultData> {
         validate_search_input(&input)?;
         validate_account_id(&input.account_id)?;
@@ -1240,6 +1248,37 @@ impl MailImapServer {
                     });
                 }
             };
+        // Resolve role aliases (Sent → Sent Messages, Trash → Deleted Messages, …)
+        // so response mailbox / message_ids / cursors use the provider's real name.
+        input.mailbox =
+            match imap::resolve_mailbox_name(&self.config, &mut session, &input.mailbox).await {
+                Ok(mailbox) => mailbox,
+                Err(error) => {
+                    let issue = ToolIssue::from_error("resolve_mailbox_name", &error);
+                    let issues = vec![issue];
+                    log_runtime_issues(
+                        "imap_search_messages",
+                        "failed",
+                        &input.account_id,
+                        Some(&input.mailbox),
+                        &issues,
+                    );
+                    return Ok(SearchResultData {
+                        status: "failed".to_owned(),
+                        issues,
+                        next_action: next_action_list_mailboxes(&input.account_id),
+                        account_id: input.account_id,
+                        mailbox: input.mailbox,
+                        total: 0,
+                        attempted: 0,
+                        returned: 0,
+                        failed: 0,
+                        messages: Vec::new(),
+                        next_cursor: None,
+                        has_more: false,
+                    });
+                }
+            };
         let uidvalidity =
             match imap::select_mailbox_readonly(&self.config, &mut session, &input.mailbox).await {
                 Ok(uidvalidity) => uidvalidity,
@@ -1256,7 +1295,7 @@ impl MailImapServer {
                     return Ok(SearchResultData {
                         status: "failed".to_owned(),
                         issues,
-                        next_action: next_action_retry_verify(&input.account_id),
+                        next_action: next_action_list_mailboxes(&input.account_id),
                         account_id: input.account_id,
                         mailbox: input.mailbox,
                         total: 0,
@@ -1973,6 +2012,9 @@ impl MailImapServer {
         let mut steps_succeeded = 0usize;
         let mut steps_attempted = 0usize;
 
+        // Resolved destination (same-account path); cross-account resolves on dest session.
+        let mut destination_mailbox = input.destination_mailbox.clone();
+
         if destination_account_id == input.account_id {
             let account = self.config.get_account(&input.account_id)?;
             steps_attempted += 1;
@@ -2005,7 +2047,7 @@ impl MailImapServer {
                         "source_account_id": input.account_id,
                         "destination_account_id": destination_account_id,
                         "source_mailbox": msg_id.mailbox,
-                        "destination_mailbox": input.destination_mailbox,
+                        "destination_mailbox": destination_mailbox,
                         "message_id": encoded_message_id,
                         "new_message_id": serde_json::Value::Null,
                         "steps_attempted": steps_attempted,
@@ -2013,13 +2055,16 @@ impl MailImapServer {
                     }));
                 }
             };
+            destination_mailbox =
+                imap::resolve_mailbox_name(&self.config, &mut session, &destination_mailbox)
+                    .await?;
             ensure_uidvalidity_matches_readwrite(&self.config, &mut session, &msg_id).await?;
             steps_attempted += 1;
             if let Err(error) = imap::uid_copy(
                 &self.config,
                 &mut session,
                 msg_id.uid,
-                input.destination_mailbox.as_str(),
+                destination_mailbox.as_str(),
             )
             .await
             {
@@ -2063,7 +2108,7 @@ impl MailImapServer {
                         "source_account_id": input.account_id,
                         "destination_account_id": destination_account_id,
                         "source_mailbox": msg_id.mailbox,
-                        "destination_mailbox": input.destination_mailbox,
+                        "destination_mailbox": destination_mailbox,
                         "message_id": encoded_message_id,
                         "new_message_id": serde_json::Value::Null,
                         "steps_attempted": steps_attempted,
@@ -2099,7 +2144,7 @@ impl MailImapServer {
                         "source_account_id": input.account_id,
                         "destination_account_id": destination_account_id,
                         "source_mailbox": msg_id.mailbox,
-                        "destination_mailbox": input.destination_mailbox,
+                        "destination_mailbox": destination_mailbox,
                         "message_id": encoded_message_id,
                         "new_message_id": serde_json::Value::Null,
                         "steps_attempted": steps_attempted,
@@ -2140,7 +2185,7 @@ impl MailImapServer {
                         "source_account_id": input.account_id,
                         "destination_account_id": destination_account_id,
                         "source_mailbox": msg_id.mailbox,
-                        "destination_mailbox": input.destination_mailbox,
+                        "destination_mailbox": destination_mailbox,
                         "message_id": encoded_message_id,
                         "new_message_id": serde_json::Value::Null,
                         "steps_attempted": steps_attempted,
@@ -2148,11 +2193,17 @@ impl MailImapServer {
                     }));
                 }
             };
+            destination_mailbox = imap::resolve_mailbox_name(
+                &self.config,
+                &mut destination_session,
+                &destination_mailbox,
+            )
+            .await?;
             steps_attempted += 1;
             if let Err(error) = imap::append(
                 &self.config,
                 &mut destination_session,
-                input.destination_mailbox.as_str(),
+                destination_mailbox.as_str(),
                 raw.as_slice(),
             )
             .await
@@ -2181,7 +2232,7 @@ impl MailImapServer {
             "source_account_id": input.account_id,
             "destination_account_id": destination_account_id,
             "source_mailbox": msg_id.mailbox,
-            "destination_mailbox": input.destination_mailbox,
+            "destination_mailbox": destination_mailbox,
             "message_id": encoded_message_id,
             "new_message_id": serde_json::Value::Null,
             "steps_attempted": steps_attempted,
@@ -2201,6 +2252,7 @@ impl MailImapServer {
         let mut issues = Vec::new();
         let mut steps_attempted = 0usize;
         let mut steps_succeeded = 0usize;
+        let mut destination_mailbox = input.destination_mailbox.clone();
 
         steps_attempted += 1;
         let mut session =
@@ -2228,7 +2280,7 @@ impl MailImapServer {
                         "issues": issues,
                         "account_id": input.account_id,
                         "source_mailbox": msg_id.mailbox,
-                        "destination_mailbox": input.destination_mailbox,
+                        "destination_mailbox": destination_mailbox,
                         "message_id": encoded_message_id,
                         "new_message_id": serde_json::Value::Null,
                         "steps_attempted": steps_attempted,
@@ -2236,6 +2288,8 @@ impl MailImapServer {
                     }));
                 }
             };
+        destination_mailbox =
+            imap::resolve_mailbox_name(&self.config, &mut session, &destination_mailbox).await?;
         ensure_uidvalidity_matches_readwrite(&self.config, &mut session, &msg_id).await?;
 
         steps_attempted += 1;
@@ -2263,7 +2317,7 @@ impl MailImapServer {
                     "issues": issues,
                     "account_id": input.account_id,
                     "source_mailbox": msg_id.mailbox,
-                    "destination_mailbox": input.destination_mailbox,
+                    "destination_mailbox": destination_mailbox,
                     "message_id": encoded_message_id,
                     "new_message_id": serde_json::Value::Null,
                     "steps_attempted": steps_attempted,
@@ -2278,7 +2332,7 @@ impl MailImapServer {
                 &self.config,
                 &mut session,
                 msg_id.uid,
-                input.destination_mailbox.as_str(),
+                destination_mailbox.as_str(),
             )
             .await
             {
@@ -2296,7 +2350,7 @@ impl MailImapServer {
                 &self.config,
                 &mut session,
                 msg_id.uid,
-                input.destination_mailbox.as_str(),
+                destination_mailbox.as_str(),
             )
             .await
             {
@@ -2363,7 +2417,7 @@ impl MailImapServer {
             "issues": issues,
             "account_id": input.account_id,
             "source_mailbox": msg_id.mailbox,
-            "destination_mailbox": input.destination_mailbox,
+            "destination_mailbox": destination_mailbox,
             "message_id": encoded_message_id,
             "new_message_id": serde_json::Value::Null,
             "steps_attempted": steps_attempted,
@@ -2544,11 +2598,13 @@ impl MailImapServer {
         let mut session =
             imap::connect_authenticated(&self.config, account, self.token_manager.as_deref())
                 .await?;
+        let mailbox =
+            imap::resolve_mailbox_name(&self.config, &mut session, &input.mailbox).await?;
         let (messages, unseen, recent) =
-            imap::mailbox_status(&self.config, &mut session, &input.mailbox).await?;
+            imap::mailbox_status(&self.config, &mut session, &mailbox).await?;
 
         let status_info = MailboxStatusInfo {
-            name: input.mailbox.clone(),
+            name: mailbox,
             messages,
             unseen,
             recent,
@@ -2596,9 +2652,15 @@ impl MailImapServer {
             imap::connect_authenticated(&self.config, account, self.token_manager.as_deref())
                 .await?;
 
+        let source_mailbox =
+            imap::resolve_mailbox_name(&self.config, &mut session, &input.mailbox).await?;
+        let destination_mailbox =
+            imap::resolve_mailbox_name(&self.config, &mut session, &input.destination_mailbox)
+                .await?;
+
         // Search (read-only SELECT via EXAMINE)
         let uidvalidity =
-            imap::select_mailbox_readonly(&self.config, &mut session, &input.mailbox).await?;
+            imap::select_mailbox_readonly(&self.config, &mut session, &source_mailbox).await?;
         let query = build_search_query(&search_input)?;
         let all_uids = imap::uid_search(&self.config, &mut session, &query).await?;
 
@@ -2607,8 +2669,8 @@ impl MailImapServer {
             return Ok(serde_json::json!({
                 "status": "ok",
                 "account_id": input.account_id,
-                "source_mailbox": input.mailbox,
-                "destination_mailbox": input.destination_mailbox,
+                "source_mailbox": source_mailbox,
+                "destination_mailbox": destination_mailbox,
                 "total_matched": 0,
                 "moved_count": 0,
                 "has_more": false,
@@ -2625,7 +2687,7 @@ impl MailImapServer {
         // Need read-write SELECT for MOVE; re-open the mailbox
         // (async-imap requires re-SELECT after EXAMINE)
         let rw_uidvalidity =
-            imap::select_mailbox_readwrite(&self.config, &mut session, &input.mailbox).await?;
+            imap::select_mailbox_readwrite(&self.config, &mut session, &source_mailbox).await?;
         if rw_uidvalidity != uidvalidity {
             return Err(AppError::Conflict(
                 "UIDVALIDITY changed between search and move".to_owned(),
@@ -2634,21 +2696,9 @@ impl MailImapServer {
 
         let caps = imap::capabilities(&self.config, &mut session).await?;
         if caps.has_str("MOVE") {
-            imap::uid_move_bulk(
-                &self.config,
-                &mut session,
-                &uid_set,
-                &input.destination_mailbox,
-            )
-            .await?;
+            imap::uid_move_bulk(&self.config, &mut session, &uid_set, &destination_mailbox).await?;
         } else {
-            imap::uid_copy_bulk(
-                &self.config,
-                &mut session,
-                &uid_set,
-                &input.destination_mailbox,
-            )
-            .await?;
+            imap::uid_copy_bulk(&self.config, &mut session, &uid_set, &destination_mailbox).await?;
             imap::uid_store_bulk(
                 &self.config,
                 &mut session,
@@ -2665,8 +2715,8 @@ impl MailImapServer {
         Ok(serde_json::json!({
             "status": "ok",
             "account_id": input.account_id,
-            "source_mailbox": input.mailbox,
-            "destination_mailbox": input.destination_mailbox,
+            "source_mailbox": source_mailbox,
+            "destination_mailbox": destination_mailbox,
             "total_matched": total_matched,
             "moved_count": moved_count,
             "remaining": remaining,
@@ -2712,8 +2762,11 @@ impl MailImapServer {
             imap::connect_authenticated(&self.config, account, self.token_manager.as_deref())
                 .await?;
 
+        let mailbox =
+            imap::resolve_mailbox_name(&self.config, &mut session, &input.mailbox).await?;
+
         let uidvalidity =
-            imap::select_mailbox_readonly(&self.config, &mut session, &input.mailbox).await?;
+            imap::select_mailbox_readonly(&self.config, &mut session, &mailbox).await?;
         let query = build_search_query(&search_input)?;
         let all_uids = imap::uid_search(&self.config, &mut session, &query).await?;
 
@@ -2722,7 +2775,7 @@ impl MailImapServer {
             return Ok(serde_json::json!({
                 "status": "ok",
                 "account_id": input.account_id,
-                "mailbox": input.mailbox,
+                "mailbox": mailbox,
                 "total_matched": 0,
                 "deleted_count": 0,
                 "has_more": false,
@@ -2737,7 +2790,7 @@ impl MailImapServer {
             .join(",");
 
         let rw_uidvalidity =
-            imap::select_mailbox_readwrite(&self.config, &mut session, &input.mailbox).await?;
+            imap::select_mailbox_readwrite(&self.config, &mut session, &mailbox).await?;
         if rw_uidvalidity != uidvalidity {
             return Err(AppError::Conflict(
                 "UIDVALIDITY changed between search and delete".to_owned(),
@@ -2759,7 +2812,7 @@ impl MailImapServer {
         Ok(serde_json::json!({
             "status": "ok",
             "account_id": input.account_id,
-            "mailbox": input.mailbox,
+            "mailbox": mailbox,
             "total_matched": total_matched,
             "deleted_count": deleted_count,
             "remaining": remaining,
@@ -2786,6 +2839,10 @@ impl MailImapServer {
             imap::connect_authenticated(&self.config, account, self.token_manager.as_deref())
                 .await?;
 
+        let destination_mailbox =
+            imap::resolve_mailbox_name(&self.config, &mut session, &input.destination_mailbox)
+                .await?;
+
         let uidvalidity =
             imap::select_mailbox_readwrite(&self.config, &mut session, &parsed.mailbox).await?;
         if uidvalidity != parsed.uidvalidity {
@@ -2796,21 +2853,9 @@ impl MailImapServer {
 
         let caps = imap::capabilities(&self.config, &mut session).await?;
         if caps.has_str("MOVE") {
-            imap::uid_move_bulk(
-                &self.config,
-                &mut session,
-                &uid_set,
-                &input.destination_mailbox,
-            )
-            .await?;
+            imap::uid_move_bulk(&self.config, &mut session, &uid_set, &destination_mailbox).await?;
         } else {
-            imap::uid_copy_bulk(
-                &self.config,
-                &mut session,
-                &uid_set,
-                &input.destination_mailbox,
-            )
-            .await?;
+            imap::uid_copy_bulk(&self.config, &mut session, &uid_set, &destination_mailbox).await?;
             imap::uid_store_bulk(
                 &self.config,
                 &mut session,
@@ -2825,7 +2870,7 @@ impl MailImapServer {
             "status": "ok",
             "account_id": input.account_id,
             "source_mailbox": parsed.mailbox,
-            "destination_mailbox": input.destination_mailbox,
+            "destination_mailbox": destination_mailbox,
             "moved_count": parsed.uids.len(),
         }))
     }
@@ -2964,10 +3009,12 @@ impl MailImapServer {
         let mut session =
             imap::connect_authenticated(&self.config, account, self.token_manager.as_deref())
                 .await?;
+        let mailbox =
+            imap::resolve_mailbox_name(&self.config, &mut session, &input.mailbox).await?;
         imap::append(
             &self.config,
             &mut session,
-            &input.mailbox,
+            &mailbox,
             input.raw_message.as_bytes(),
         )
         .await?;
@@ -2975,7 +3022,7 @@ impl MailImapServer {
         Ok(serde_json::json!({
             "status": "ok",
             "account_id": input.account_id,
-            "mailbox": input.mailbox,
+            "mailbox": mailbox,
             "size_bytes": input.raw_message.len(),
         }))
     }
@@ -3448,49 +3495,12 @@ impl MailImapServer {
         let sent_folder = mailboxes
             .iter()
             .map(|m| m.name().to_owned())
-            .find(|name| is_sent_folder_name(name))
+            .find(|name| imap::is_sent_folder_name(name))
             .unwrap_or_else(|| "Sent".to_owned());
 
         imap::append(&self.config, &mut session, &sent_folder, rfc822).await?;
         Ok(())
     }
-}
-
-/// Return `true` if `name` looks like a Sent folder on any major provider,
-/// including common non-English names. Case-insensitive.
-fn is_sent_folder_name(name: &str) -> bool {
-    let lower = name.to_ascii_lowercase();
-    // Fast path: exact matches for common top-level names (English + localized)
-    matches!(
-        lower.as_str(),
-        "sent"
-            | "sent items"
-            | "sent mail"
-            | "sent messages"
-            | "enviado"
-            | "enviados"
-            | "enviadas"
-            | "elementos enviados"
-            | "correo enviado"
-            | "itens enviados"
-            | "mensagens enviadas"
-            | "envoyés"
-            | "éléments envoyés"
-            | "gesendet"
-            | "gesendete elemente"
-            | "posta inviata"
-            | "inviati"
-            | "verzonden"
-            | "wyslane"
-            | "wysłane"
-    ) || lower.ends_with("/sent")
-        || lower.ends_with("/sent items")
-        || lower.ends_with("/sent mail")
-        || lower.ends_with("/sent messages")
-        || lower.ends_with("/enviado")
-        || lower.ends_with("/enviados")
-        || lower.ends_with("/elementos enviados")
-        || lower.contains("[gmail]/sent")
 }
 
 /// Calculate elapsed milliseconds
@@ -4488,10 +4498,11 @@ fn parse_bulk_message_ids(account_id: &str, message_ids: &[String]) -> AppResult
 /// Tests for server-side validation and encoding helpers.
 mod tests {
     use super::{
-        encode_raw_source_base64, escape_imap_quoted, is_sent_folder_name,
-        sanitize_attachment_filename, select_attachment, validate_email_no_wrapper_leak,
-        validate_flag, validate_mailbox, validate_search_text,
+        encode_raw_source_base64, escape_imap_quoted, sanitize_attachment_filename,
+        select_attachment, validate_email_no_wrapper_leak, validate_flag, validate_mailbox,
+        validate_search_text,
     };
+    use crate::imap::is_sent_folder_name;
     use crate::mime::ExtractedAttachment;
 
     fn att(part_id: &str, filename: Option<&str>) -> ExtractedAttachment {


### PR DESCRIPTION
## Summary
iCloud IMAP returns empty bodies for `RFC822` FETCH, so `imap_get_message` and related tools failed with "message has no RFC822 body". This PR fetches with `BODY.PEEK[]` first (RFC822 fallback), resolves common mailbox aliases to Apple folder names (`Sent` → `Sent Messages`, `Trash` → `Deleted Messages`), and documents iCloud setup next to Gmail/Zoho. Also adds `scripts/run-mcp.sh` so local MCP hosts that start outside the repo still load `.env`.

## Why
Third-party IMAP clients against `imap.mail.me.com` need BODY section fetches; Apple uses different system folder names than Gmail/Exchange. Without this, read tools and naive `Sent`/`Trash` paths fail on otherwise valid accounts.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo test` (84 passed, 3 ignored)
- [x] Unit tests for alias resolution (iCloud + Gmail folder names)
- [x] Live smoke against a real iCloud account: login, `Sent`/`Trash` resolve, `fetch_raw_message` returns full message bytes (`BODY.PEEK[]`); `RFC822` still empty as expected
- [ ] Reviewer: optional retest with an iCloud app-specific password after merge

## Notes
- iCloud is **not** added to `provider_auto_saves_sent` (SMTP does not auto-file Sent for third-party clients; MCP APPEND to Sent remains the default).
- Pre-existing clippy warnings on `main` are unchanged.