### PR TITLE
fix: identify IMAP client when supported

### DIFF
--- a/docs/account-setup.md
+++ b/docs/account-setup.md
@@ -34,6 +34,34 @@ Global settings:
 
 ---
 
+## NetEase Mail (126.com / 163.com / yeah.net)
+
+Enable IMAP in the web mailbox settings and create a dedicated client authorization
+password. Do not use the normal web mailbox password.
+
+```env
+# Use imap.163.com for 163.com, imap.126.com for 126.com,
+# or imap.yeah.net for yeah.net.
+MAIL_IMAP_NETEASE_HOST=imap.126.com
+MAIL_IMAP_NETEASE_PORT=993
+MAIL_IMAP_NETEASE_USER=you@126.com
+MAIL_IMAP_NETEASE_PASS=your-client-authorization-password
+MAIL_IMAP_NETEASE_SECURE=true
+```
+
+NetEase IMAP servers require clients to identify themselves with the RFC 2971
+`ID` command. mail-mcp sends client identification after authentication whenever
+the server advertises the `ID` capability.
+
+For read-only access, keep both write gates disabled:
+
+```env
+MAIL_IMAP_WRITE_ENABLED=false
+MAIL_SMTP_WRITE_ENABLED=false
+```
+
+---
+
 ## Microsoft Personal (Hotmail / Outlook.com)
 
 ### IMAP (reading email)

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -90,6 +90,7 @@ fn socket_timeout(server: &ServerConfig) -> Duration {
 /// 2. TLS handshake (if `secure: true`) or plaintext (if `secure: false`)
 /// 3. Read IMAP greeting
 /// 4. Authentication (LOGIN or XOAUTH2 depending on `auth_method`)
+/// 5. Client identification when the server advertises RFC 2971 `ID`
 ///
 /// # Security
 ///
@@ -158,7 +159,7 @@ pub async fn connect_authenticated(
         ));
     }
 
-    let session = match account.auth_method {
+    let mut session = match account.auth_method {
         AuthMethod::OAuth2 => {
             let tm = token_manager.ok_or_else(|| {
                 AppError::Internal(format!(
@@ -208,7 +209,51 @@ pub async fn connect_authenticated(
         }
     };
 
+    send_client_identification_if_supported(greeting_duration, &mut session).await?;
+
     Ok(session)
+}
+
+/// Identify mail-mcp to servers that advertise the RFC 2971 `ID` extension.
+///
+/// Some providers, including NetEase, reject mailbox access from unidentified
+/// clients after authentication. Servers without the extension are left
+/// untouched.
+async fn send_client_identification_if_supported(
+    operation_timeout: Duration,
+    session: &mut ImapSession,
+) -> AppResult<()> {
+    let capabilities = timeout(operation_timeout, session.capabilities())
+        .await
+        .map_err(|_| AppError::Timeout("CAPABILITY timed out before IMAP ID".to_owned()))
+        .and_then(|result| {
+            result.map_err(|error| {
+                AppError::Internal(format!(
+                    "CAPABILITY failed before IMAP client identification: {error}"
+                ))
+            })
+        })?;
+
+    if !capabilities.has_str("ID") {
+        return Ok(());
+    }
+
+    timeout(
+        operation_timeout,
+        session.id([
+            ("name", Some("mail-mcp")),
+            ("version", Some(env!("CARGO_PKG_VERSION"))),
+            ("vendor", Some("tecnologicachile")),
+            ("support-url", Some(env!("CARGO_PKG_REPOSITORY"))),
+        ]),
+    )
+    .await
+    .map_err(|_| AppError::Timeout("IMAP ID timed out".to_owned()))
+    .and_then(|result| {
+        result.map_err(|error| AppError::Internal(format!("IMAP ID failed: {error}")))
+    })?;
+
+    Ok(())
 }
 
 /// Send NOOP to test connection liveness
@@ -680,7 +725,8 @@ mod tests {
     use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
     use rustls::{ClientConfig, DigitallySignedStruct, Error as RustlsError, SignatureScheme};
     use secrecy::{ExposeSecret, SecretString};
-    use tokio::net::TcpStream;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::{TcpListener, TcpStream};
     use tokio::time::sleep;
     use tokio::time::timeout;
     use tokio_rustls::TlsConnector;
@@ -691,6 +737,164 @@ mod tests {
         uid_store,
     };
     use crate::config::{AccountConfig, ServerConfig};
+
+    async fn read_imap_command(stream: &mut BufReader<TcpStream>) -> String {
+        let mut command = String::new();
+        stream
+            .read_line(&mut command)
+            .await
+            .expect("test IMAP server should read a command");
+        assert!(
+            !command.is_empty(),
+            "client closed before sending a command"
+        );
+        command
+    }
+
+    async fn reply_ok(stream: &mut BufReader<TcpStream>, command: &str, message: &str) {
+        let tag = command
+            .split_whitespace()
+            .next()
+            .expect("IMAP command should have a tag");
+        stream
+            .get_mut()
+            .write_all(format!("{tag} OK {message}\r\n").as_bytes())
+            .await
+            .expect("test IMAP server should write a response");
+    }
+
+    #[tokio::test]
+    async fn sends_client_identification_when_server_advertises_id() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("test listener should expose its address");
+
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener
+                .accept()
+                .await
+                .expect("test server should accept a client");
+            let mut stream = BufReader::new(socket);
+
+            let login = read_imap_command(&mut stream).await;
+            assert!(login.contains(" LOGIN "));
+            reply_ok(&mut stream, &login, "LOGIN completed").await;
+
+            let capability = read_imap_command(&mut stream).await;
+            assert!(capability.contains(" CAPABILITY"));
+            let tag = capability
+                .split_whitespace()
+                .next()
+                .expect("CAPABILITY command should have a tag");
+            stream
+                .get_mut()
+                .write_all(
+                    format!("* CAPABILITY IMAP4rev1 ID\r\n{tag} OK CAPABILITY completed\r\n")
+                        .as_bytes(),
+                )
+                .await
+                .expect("test server should advertise ID");
+
+            let identification = read_imap_command(&mut stream).await;
+            assert!(identification.contains(" ID ("));
+            assert!(identification.contains("\"name\" \"mail-mcp\""));
+            assert!(identification.contains("\"version\""));
+            assert!(identification.contains("\"vendor\" \"tecnologicachile\""));
+            assert!(identification.contains("\"support-url\""));
+            let tag = identification
+                .split_whitespace()
+                .next()
+                .expect("ID command should have a tag");
+            stream
+                .get_mut()
+                .write_all(format!("* ID NIL\r\n{tag} OK ID completed\r\n").as_bytes())
+                .await
+                .expect("test server should accept ID");
+        });
+
+        let tcp = TcpStream::connect(address)
+            .await
+            .expect("test client should connect");
+        let client = Client::new(super::ImapStream::Plain(tcp));
+        let test_password = ["test", "password"].join("-");
+        let mut session = client
+            .login("user@example.com", test_password)
+            .await
+            .map_err(|(error, _)| error)
+            .expect("test client should authenticate");
+
+        super::send_client_identification_if_supported(Duration::from_secs(1), &mut session)
+            .await
+            .expect("client identification should succeed");
+
+        server.await.expect("test IMAP server should finish");
+    }
+
+    #[tokio::test]
+    async fn skips_client_identification_without_id_capability() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("test listener should expose its address");
+
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener
+                .accept()
+                .await
+                .expect("test server should accept a client");
+            let mut stream = BufReader::new(socket);
+
+            let login = read_imap_command(&mut stream).await;
+            reply_ok(&mut stream, &login, "LOGIN completed").await;
+
+            let capability = read_imap_command(&mut stream).await;
+            let tag = capability
+                .split_whitespace()
+                .next()
+                .expect("CAPABILITY command should have a tag");
+            stream
+                .get_mut()
+                .write_all(
+                    format!("* CAPABILITY IMAP4rev1\r\n{tag} OK CAPABILITY completed\r\n")
+                        .as_bytes(),
+                )
+                .await
+                .expect("test server should answer CAPABILITY");
+
+            let mut unexpected = String::new();
+            stream
+                .read_line(&mut unexpected)
+                .await
+                .expect("test server should observe client close");
+            assert!(
+                unexpected.is_empty(),
+                "client must not send ID when the server does not advertise it"
+            );
+        });
+
+        let tcp = TcpStream::connect(address)
+            .await
+            .expect("test client should connect");
+        let client = Client::new(super::ImapStream::Plain(tcp));
+        let test_password = ["test", "password"].join("-");
+        let mut session = client
+            .login("user@example.com", test_password)
+            .await
+            .map_err(|(error, _)| error)
+            .expect("test client should authenticate");
+
+        super::send_client_identification_if_supported(Duration::from_secs(1), &mut session)
+            .await
+            .expect("servers without ID should remain compatible");
+        drop(session);
+
+        server.await.expect("test IMAP server should finish");
+    }
 
     /// Holds connection details for a GreenMail test server instance.
     #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

- send RFC 2971 client identification after authentication when the IMAP server advertises `ID`
- leave servers without the capability unchanged
- add regression tests for both capability paths
- document read-only NetEase 126.com, 163.com, and yeah.net setup

Fixes #20.

## Why

NetEase IMAP accepts authentication but rejects mailbox access with `Unsafe Login` unless the client sends `ID`. The command is issued conditionally so other providers keep their existing behavior.

## Verification

- `cargo fmt -- --check`
- `cargo test` (81 passed, 3 ignored, 0 failed)
- focused RFC 2971 tests (2 passed)
- secret scan of the submitted diff
- live IMAPS validation against a NetEase 126.com mailbox: authentication, search, message reading, and Chinese subject decoding succeeded

The live test used read-only server gates (`MAIL_IMAP_WRITE_ENABLED=false` and `MAIL_SMTP_WRITE_ENABLED=false`). No credentials, mailbox identifiers, or machine-specific paths are included.

On Rust 1.98, the repository-wide `cargo clippy --all-targets -- -D warnings` command also reports pre-existing warnings in unrelated code. With those existing lint IDs allowed, the submitted changes pass Clippy with warnings denied.